### PR TITLE
Move Settings.init() below runApp()

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,8 +14,12 @@ void main() async {
   await findSystemLocale();
   initializeDateFormatting(Intl.systemLocale, null);
   tz.initializeTimeZones();
-  await Settings.init();
   runApp(const MyApp());
+  // The following must be run after runApp. While the Android app requires only
+  // WidgetsFlutterBinding.ensureInitialized(), this is not sufficient for the
+  // release web app build. (Note that the debug web app is not affected, so
+  // always test it in a release build.)
+  await Settings.init();
 }
 
 class MyApp extends StatefulWidget {

--- a/lib/utils/settings.dart
+++ b/lib/utils/settings.dart
@@ -19,7 +19,6 @@ class Settings {
 
   static Future<void> init() async {
     Settings instance = getInstance();
-    WidgetsFlutterBinding.ensureInitialized(); // Required by SharedPreferences.
     instance._store = await SharedPreferences.getInstance();
     instance
         .setBrightness(instance._store.getString(prefBrightness) ?? 'system');


### PR DESCRIPTION
The move to above breaks web release build even after WidgetsFlutterBinding.ensureInitialized() is invoked before SharedPreferences is initialized.

Sadly the breakage happens only for release web build, not "flutter run -d chrome" so it is hard to debug.