### PR TITLE
Revert "Move Settings.init() below runApp() (#25)"

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,12 +14,8 @@ void main() async {
   await findSystemLocale();
   initializeDateFormatting(Intl.systemLocale, null);
   tz.initializeTimeZones();
-  runApp(const MyApp());
-  // The following must be run after runApp. While the Android app requires only
-  // WidgetsFlutterBinding.ensureInitialized(), this is not sufficient for the
-  // release web app build. (Note that the debug web app is not affected, so
-  // always test it in a release build.)
   await Settings.init();
+  runApp(const MyApp());
 }
 
 class MyApp extends StatefulWidget {

--- a/lib/utils/settings.dart
+++ b/lib/utils/settings.dart
@@ -19,6 +19,7 @@ class Settings {
 
   static Future<void> init() async {
     Settings instance = getInstance();
+    WidgetsFlutterBinding.ensureInitialized(); // Required by SharedPreferences.
     instance._store = await SharedPreferences.getInstance();
     instance
         .setBrightness(instance._store.getString(prefBrightness) ?? 'system');


### PR DESCRIPTION
This reverts commit 408f5efa88460c8fc9d129f5f44542b95fd6d149.

The breakage described in #25 appears to be related to Flutter build system. It was fixed after a "flutter clean".